### PR TITLE
Rename everything 'resin' to 'balena'

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -1,6 +1,6 @@
 
 /*
-Copyright 2016 Resin.io
+Copyright 2016 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,6 +1,6 @@
 
 /*
-Copyright 2016 Resin.io
+Copyright 2016 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var convertFilePathDefinition, resin, _;
+var balena, convertFilePathDefinition, _;
 
 _ = require('lodash');
 
-resin = require('resin-sdk-preconfigured');
+balena = require('balena-sdk').fromSharedOptions();
 
 
 /**
@@ -37,11 +37,11 @@ resin = require('resin-sdk-preconfigured');
  */
 
 exports.getConfigPartitionInformationByType = function(type) {
-  return resin.models.device.getManifestBySlug(type).then(function(manifest) {
+  return balena.models.device.getManifestBySlug(type).then(function(manifest) {
     var config, _ref;
     config = (_ref = manifest.configuration) != null ? _ref.config : void 0;
     if (config == null) {
-      throw new Error("Unsupported device type: " + type);
+      throw new balena.errors.BalenaInvalidDeviceType(type);
     }
     return convertFilePathDefinition(config);
   });

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -1,29 +1,27 @@
-resin-config-json
+balena-config-json
 -----------------
 
-[![npm version](https://badge.fury.io/js/resin-config-json.svg)](http://badge.fury.io/js/resin-config-json)
-[![dependencies](https://david-dm.org/resin-io/resin-config-json.png)](https://david-dm.org/resin-io/resin-config-json.png)
-[![Build Status](https://travis-ci.org/resin-io/resin-config-json.svg?branch=master)](https://travis-ci.org/resin-io/resin-config-json)
-[![Build status](https://ci.appveyor.com/api/projects/status/ndm6cfnvotbsyaqx/branch/master?svg=true)](https://ci.appveyor.com/project/resin-io/resin-config-json/branch/master)
+[![npm version](https://badge.fury.io/js/balena-config-json.svg)](http://badge.fury.io/js/balena-config-json)
+[![dependencies](https://david-dm.org/balena-io/balena-config-json.png)](https://david-dm.org/balena-io/balena-config-json.png)
+[![Build Status](https://travis-ci.org/balena-io/balena-config-json.svg?branch=master)](https://travis-ci.org/balena-io/balena-config-json)
+[![Build status](https://ci.appveyor.com/api/projects/status/ndm6cfnvotbsyaqx/branch/master?svg=true)](https://ci.appveyor.com/project/balena-io/balena-config-json/branch/master)
 
-Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.png)](https://gitter.im/resin-io/chat)
-
-Resin.io config.json manipulation utilities.
+Balena config.json manipulation utilities.
 
 Role
 ----
 
-The intention of this module is to provide low level utilities to read and write `config.json` from Resin.io devices.
+The intention of this module is to provide low level utilities to read and write `config.json` from balena devices.
 
 **THIS MODULE IS LOW LEVEL AND IS NOT MEANT TO BE USED BY END USERS DIRECTLY**.
 
 Installation
 ------------
 
-Install `resin-config-json` by running:
+Install `balena-config-json` by running:
 
 ```sh
-$ npm install --save resin-config-json
+$ npm install --save balena-config-json
 ```
 
 Documentation
@@ -39,7 +37,7 @@ Documentation
 Support
 -------
 
-If you're having any problem, please [raise an issue](https://github.com/resin-io/resin-config-json/issues/new) on GitHub and the Resin.io team will be happy to help.
+If you're having any problem, please [raise an issue](https://github.com/balena-io/balena-config-json/issues/new) on GitHub and the balena team will be happy to help.
 
 Tests
 -----
@@ -53,8 +51,8 @@ $ gulp test
 Contribute
 ----------
 
-- Issue Tracker: [github.com/resin-io/resin-config-json/issues](https://github.com/resin-io/resin-config-json/issues)
-- Source Code: [github.com/resin-io/resin-config-json](https://github.com/resin-io/resin-config-json)
+- Issue Tracker: [github.com/balena-io/balena-config-json/issues](https://github.com/balena-io/balena-config-json/issues)
+- Source Code: [github.com/balena-io/balena-config-json](https://github.com/balena-io/balena-config-json)
 
 Before submitting a PR, please make sure that you include tests, and that [coffeelint](http://www.coffeelint.org/) runs without any warning:
 

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,5 +1,5 @@
 ###
-Copyright 2016 Resin.io
+Copyright 2016 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,5 +1,5 @@
 ###
-Copyright 2016 Resin.io
+Copyright 2016 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@ limitations under the License.
 ###
 
 _ = require('lodash')
-resin = require('resin-sdk-preconfigured')
+balena = require('balena-sdk').fromSharedOptions()
 
 ###*
 # @summary Get config partition information
@@ -32,11 +32,11 @@ resin = require('resin-sdk-preconfigured')
 # 	console.log(configuration.path)
 ###
 exports.getConfigPartitionInformationByType = (type) ->
-	return resin.models.device.getManifestBySlug(type).then (manifest) ->
+	return balena.models.device.getManifestBySlug(type).then (manifest) ->
 		config = manifest.configuration?.config
 
 		if not config?
-			throw new Error("Unsupported device type: #{type}")
+			throw new balena.errors.BalenaInvalidDeviceType(type)
 
 		return convertFilePathDefinition(config)
 

--- a/package.json
+++ b/package.json
@@ -35,12 +35,13 @@
     "jsdoc-to-markdown": "^1.1.1",
     "mocha": "~2.0.1",
     "mochainon": "^1.0.0",
+    "mockery": "^2.1.0",
     "wary": "^1.0.0"
   },
   "dependencies": {
+    "balena-sdk": "v11.0.0",
     "bluebird": "^3.0.5",
     "lodash": "^4.17.10",
-    "resin-image-fs": "^5.0.4",
-    "resin-sdk-preconfigured": "^0.1.0"
+    "resin-image-fs": "^5.0.4"
   }
 }

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,6 +1,11 @@
 m = require('mochainon')
 Promise = require('bluebird')
-resin = require('resin-sdk-preconfigured')
+mockery = require('mockery')
+balena = require('balena-sdk').fromSharedOptions()
+
+mockery.enable({ warnOnReplace: false, warnOnUnregistered: false })
+mockery.registerMock('balena-sdk', { fromSharedOptions: -> balena })
+
 utils = require('../lib/utils')
 
 describe 'Utils:', ->
@@ -10,7 +15,7 @@ describe 'Utils:', ->
 		describe 'given a raspberry-pi manifest', ->
 
 			beforeEach ->
-				@getManifestBySlugStub = m.sinon.stub(resin.models.device, 'getManifestBySlug')
+				@getManifestBySlugStub = m.sinon.stub(balena.models.device, 'getManifestBySlug')
 				@getManifestBySlugStub.withArgs('raspberry-pi').returns Promise.resolve
 					configuration:
 						config:
@@ -31,7 +36,7 @@ describe 'Utils:', ->
 		describe 'given an edison manifest', ->
 
 			beforeEach ->
-				@getManifestBySlugStub = m.sinon.stub(resin.models.device, 'getManifestBySlug')
+				@getManifestBySlugStub = m.sinon.stub(balena.models.device, 'getManifestBySlug')
 				@getManifestBySlugStub.withArgs('edison').returns Promise.resolve
 					configuration:
 						config:
@@ -50,7 +55,7 @@ describe 'Utils:', ->
 		describe 'given a device type manifest without a configuration property', ->
 
 			beforeEach ->
-				@getManifestBySlugStub = m.sinon.stub(resin.models.device, 'getManifestBySlug')
+				@getManifestBySlugStub = m.sinon.stub(balena.models.device, 'getManifestBySlug')
 				@getManifestBySlugStub.returns(Promise.resolve({}))
 
 			afterEach ->
@@ -58,12 +63,12 @@ describe 'Utils:', ->
 
 			it 'should be rejected with an error', ->
 				promise = utils.getConfigPartitionInformationByType('foobar')
-				m.chai.expect(promise).to.be.rejectedWith('Unsupported device type: foobar')
+				m.chai.expect(promise).to.be.rejectedWith('Invalid device type: foobar')
 
 		describe 'given a device type manifest with a new format partition identifier', ->
 
 			beforeEach ->
-				@getManifestBySlugStub = m.sinon.stub(resin.models.device, 'getManifestBySlug')
+				@getManifestBySlugStub = m.sinon.stub(balena.models.device, 'getManifestBySlug')
 				@getManifestBySlugStub.withArgs('raspberry-pi').returns Promise.resolve
 					configuration:
 						config:
@@ -82,7 +87,7 @@ describe 'Utils:', ->
 		describe 'given a device type manifest without a configuration.config property', ->
 
 			beforeEach ->
-				@getManifestBySlugStub = m.sinon.stub(resin.models.device, 'getManifestBySlug')
+				@getManifestBySlugStub = m.sinon.stub(balena.models.device, 'getManifestBySlug')
 				@getManifestBySlugStub.returns(Promise.resolve(configuration: {}))
 
 			afterEach ->
@@ -90,4 +95,4 @@ describe 'Utils:', ->
 
 			it 'should be rejected with an error', ->
 				promise = utils.getConfigPartitionInformationByType('foobar')
-				m.chai.expect(promise).to.be.rejectedWith('Unsupported device type: foobar')
+				m.chai.expect(promise).to.be.rejectedWith('Invalid device type: foobar')


### PR DESCRIPTION
Bonus PR to rename this too as part of the CLI release. Changing this ensures that the downstream `balena config *` commands all work nicely in all cases after the rename.

Change-type: major